### PR TITLE
[date][xs]: - fixed date field format according to the spec

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -1,102 +1,106 @@
 {
-  "name": "gdp-us",
-  "title": "Gross Domestic Product of the United States (US GDP)",
-  "sources": [{
-    "name": "Bureau of Economics Analysis (US Government)",
-    "web": "http://www.bea.gov/national/index.htm#gdp"
-  }],
   "licenses": [
     {
       "id": "odc-pddl",
       "name": "Public Domain Dedication and License",
-      "version": "1.0",
-      "url": "http://opendatacommons.org/licenses/pddl/1.0/"
+      "url": "http://opendatacommons.org/licenses/pddl/1.0/",
+      "version": "1.0"
     }
   ],
+  "name": "gdp-us",
   "resources": [
     {
-      "name": "year",
-      "path": "year.csv",
       "format": "csv",
       "mediatype": "text/csv",
+      "name": "year",
+      "path": "year.csv",
       "schema": {
         "fields": [
           {
-            "name": "date",
             "description": "The year",
-            "format": "yyyy",
+            "format": "any",
+            "name": "date",
             "type": "date"
           },
           {
-            "name": "level-current",
             "description": "GDP in billions of current dollars",
+            "name": "level-current",
             "type": "number"
           },
           {
-            "name": "level-chained",
             "description": "GDP in billions of chained 2009 dollars",
+            "name": "level-chained",
             "type": "number"
           },
           {
-            "name": "change-current",
             "description": "GDP percent change based on current dollars",
+            "name": "change-current",
             "type": "number"
           },
           {
-            "name": "change-chained",
             "description": "GDP percent change based on chained 2009 dollars",
+            "name": "change-chained",
             "type": "number"
           }
         ]
       }
     },
     {
-      "name": "quarter",
-      "path": "quarter.csv",
       "format": "csv",
       "mediatype": "text/csv",
+      "name": "quarter",
+      "path": "quarter.csv",
       "schema": {
         "fields": [
           {
-            "name": "date",
             "description": "The quarter (first day of the quarter)",
-            "format": "yyyy-mm-dd",
+            "format": "any",
+            "name": "date",
             "type": "date"
           },
           {
-            "name": "level-current",
             "description": "GDP in billions of current dollars",
+            "name": "level-current",
             "type": "number"
           },
           {
-            "name": "level-chained",
             "description": "GDP in billions of chained 2009 dollars",
+            "name": "level-chained",
             "type": "number"
           },
           {
-            "name": "change-current",
             "description": "GDP percent change based on current dollars",
+            "name": "change-current",
             "type": "number"
           },
           {
-            "name": "change-chained",
             "description": "GDP percent change based on chained 2009 dollars",
+            "name": "change-chained",
             "type": "number"
           }
         ]
       }
     }
   ],
+  "sources": [
+    {
+      "name": "Bureau of Economics Analysis (US Government)",
+      "web": "http://www.bea.gov/national/index.htm#gdp"
+    }
+  ],
+  "title": "Gross Domestic Product of the United States (US GDP)",
   "views": [
     {
       "id": "Graph",
       "label": "Change in GDP",
-      "type": "Graph",
       "state": {
         "graphType": "columns",
         "group": "date",
-        "series": [ "change-chained" ]
-      }
+        "series": [
+          "change-chained"
+        ]
+      },
+      "type": "Graph"
     }
   ]
 }


### PR DESCRIPTION
Date format "yyyy" and "yyyy-mm-dd" are not supported.
Changed date "format" = "any" according to the specification:
https://pre-v1.frictionlessdata.io/json-table-schema/#date